### PR TITLE
Remove debug console log line

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -58,7 +58,6 @@ export class App extends Component {
 	}
 
 	fetchNextPage = _.throttle(async () => {
-		console.log(this.state.provider.hasMore);
 		if (this.state.provider.hasMore) {
 			this.setState({loading: true});
 			this.state.provider.limit += 25;


### PR DESCRIPTION
Removing `console.log` which does log `false` when opening logreader in recent Nextcloud 12.0.0.29