### PR TITLE
use the correct timezone when parsing log times

### DIFF
--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -49,12 +49,13 @@ class LogController extends Controller {
 
 	private function getLogIterator() {
 		$dateFormat = $this->config->getSystemValue('logdateformat', \DateTime::ATOM);
+		$timezone = $this->config->getSystemValue('logtimezone', 'UTC');
 		$logClasses = ['\OC\Log\Owncloud', '\OC_Log_Owncloud', '\OC\Log\File'];
 		foreach ($logClasses as $logClass) {
 			if (class_exists($logClass)) {
 				$handle = fopen($logClass::getLogFilePath(), 'rb');
 				if ($handle) {
-					return new LogIterator($handle, $dateFormat);
+					return new LogIterator($handle, $dateFormat, $timezone);
 				} else {
 					throw new \Exception("Error while opening ".$logClass::getLogFilePath());
 				}

--- a/lib/Log/LogIterator.php
+++ b/lib/Log/LogIterator.php
@@ -49,15 +49,19 @@ class LogIterator implements \Iterator {
 	 */
 	private $dateFormat;
 
+	private $timezone;
+
 	const CHUNK_SIZE = 100; // how many chars do we try at once to find a new line
 
 	/**
 	 * @param resource $handle
 	 * @param string $dateFormat
+	 * @param string $timezone
 	 */
-	public function __construct($handle, $dateFormat) {
+	public function __construct($handle, $dateFormat, $timezone) {
 		$this->handle = $handle;
 		$this->dateFormat = $dateFormat;
+		$this->timezone = new \DateTimeZone($timezone);
 		$this->rewind();
 		$this->next();
 	}
@@ -71,7 +75,7 @@ class LogIterator implements \Iterator {
 	function current() {
 		$entry = json_decode($this->lastLine, true);
 		if ($this->dateFormat !== \DateTime::ATOM) {
-			$time = \DateTime::createFromFormat($this->dateFormat, $entry['time']);
+			$time = \DateTime::createFromFormat($this->dateFormat, $entry['time'], $this->timezone);
 			if ($time) {
 				$entry['time'] = $time->format(\DateTime::ATOM);
 			}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/logreader/issues/42

@mightyBroccoli @qswroot can you verify if this fixes the problem for you