### PR TITLE
Do not change system loglevel when changing view filter.

### DIFF
--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -200,7 +200,6 @@ class LogController extends Controller {
 				break;
 			}
 		}
-		$this->config->setSystemValue('loglevel', $minLevel);
 		$this->config->setAppValue('logreader', 'levels', $levels);
 		return $minLevel;
 	}


### PR DESCRIPTION
This is a fix for https://github.com/nextcloud/logreader/issues/68.

As mentioned by @MorrisJobke in https://github.com/nextcloud/server/issues/9939: That log reader filter is also the setting in the UI. But I would be fine to keep it a filter only and allow only changing the log level in the config.php.