### PR TITLE
(bugfix): Protect LogIterator.php from empty array indices

### DIFF
--- a/lib/Log/LogIterator.php
+++ b/lib/Log/LogIterator.php
@@ -75,9 +75,11 @@ class LogIterator implements \Iterator {
 	function current() {
 		$entry = json_decode($this->lastLine, true);
 		if ($this->dateFormat !== \DateTime::ATOM) {
-			$time = \DateTime::createFromFormat($this->dateFormat, $entry['time'], $this->timezone);
-			if ($time) {
-				$entry['time'] = $time->format(\DateTime::ATOM);
+			if (isset($entry['time'])) {
+				$time = \DateTime::createFromFormat($this->dateFormat, $entry['time'], $this->timezone);
+				if ($time) {
+					$entry['time'] = $time->format(\DateTime::ATOM);
+				}
 			}
 		}
 		return $entry;


### PR DESCRIPTION
Add test to verify $entry['time'] is set prior to using it.

Fixes (Works around) #352