### PR TITLE
fix logreader:tail/watch commands

### DIFF
--- a/lib/Command/Tail.php
+++ b/lib/Command/Tail.php
@@ -59,7 +59,7 @@ class Tail extends Base {
 		$raw = $input->getOption('raw');
 		$count = (int)$input->getArgument('lines');
 		$io = new SymfonyStyle($input, $output);
-		$logIterator = $this->logIteratorFactory->getLogIterator('11111');
+		$logIterator = $this->logIteratorFactory->getLogIterator(Watch::ALL_LEVELS);
 		$logIterator = new \LimitIterator($logIterator, 0, $count);
 		$logItems = iterator_to_array($logIterator);
 		$logItems = array_reverse($logItems);

--- a/lib/Command/Watch.php
+++ b/lib/Command/Watch.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console\Terminal;
 
 class Watch extends Base {
 	public const LEVELS = ['Debug', 'Info', 'Warning', 'Error', 'Fatal'];
-	public const ALL_LEVELS = '11111';
+	public const ALL_LEVELS = [0, 1, 2, 3, 4];
 
 	private $formatter;
 	private $logIteratorFactory;


### PR DESCRIPTION
`LogIteratorFactory` was changed with https://github.com/nextcloud/logreader/pull/936