### PR TITLE
Add a setupcheck for errors and warnings in log file

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ namespace OCA\LogReader\AppInfo;
 
 use OCA\LogReader\Listener\LogListener;
 use OCA\LogReader\Log\Formatter;
+use OCA\LogReader\SetupChecks\LogErrors;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -42,6 +43,8 @@ class Application extends App implements IBootstrap {
 		$context->registerService(Formatter::class, function (ContainerInterface $c) {
 			return new Formatter(\OC::$SERVERROOT);
 		});
+
+		$context->registerSetupCheck(LogErrors::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/SetupChecks/LogErrors.php
+++ b/lib/SetupChecks/LogErrors.php
@@ -72,10 +72,9 @@ class LogErrors implements ISetupCheck {
 			$count[$logItem['level']]++;
 		}
 		if (array_sum($count) === 0) {
-			return new SetupResult(SetupResult::SUCCESS, $this->l10n->t('No errors in the logs since %s', $this->dateFormatter->formatDate($limit)));
+			return SetupResult::success($this->l10n->t('No errors in the logs since %s', $this->dateFormatter->formatDate($limit)));
 		} elseif ($count[self::LEVEL_ERROR] + $count[self::LEVEL_FATAL] > 0) {
-			return new SetupResult(
-				SetupResult::ERROR,
+			return SetupResult::error(
 				$this->l10n->n(
 					'%n error in the logs since %s',
 					'%n errors in the logs since %s',
@@ -84,8 +83,7 @@ class LogErrors implements ISetupCheck {
 				)
 			);
 		} else {
-			return new SetupResult(
-				SetupResult::WARNING,
+			return SetupResult::warning(
 				$this->l10n->n(
 					'%n warning in the logs since %s',
 					'%n warnings in the logs since %s'.json_encode($count),

--- a/lib/SetupChecks/LogErrors.php
+++ b/lib/SetupChecks/LogErrors.php
@@ -63,7 +63,7 @@ class LogErrors implements ISetupCheck {
 		$limit = new \DateTime('7 days ago');
 		foreach ($logIterator as $logItem) {
 			if (!isset($logItem['time'])) {
-				break;
+				continue;
 			}
 			$time = \DateTime::createFromFormat(\DateTime::ATOM, $logItem['time']);
 			if ($time < $limit) {

--- a/lib/SetupChecks/LogErrors.php
+++ b/lib/SetupChecks/LogErrors.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\LogReader\SetupChecks;
+
+use OCA\LogReader\Log\LogIteratorFactory;
+use OCP\IConfig;
+use OCP\IDateTimeFormatter;
+use OCP\IL10N;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class LogErrors implements ISetupCheck {
+	private const LEVEL_WARNING = 2;
+	private const LEVEL_ERROR = 3;
+	private const LEVEL_FATAL = 4;
+
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+		private IDateTimeFormatter $dateFormatter,
+		private LogIteratorFactory $logIteratorFactory,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Errors in the log');
+	}
+
+	public function getCategory(): string {
+		return 'system';
+	}
+
+	public function run(): SetupResult {
+		$logIterator = $this->logIteratorFactory->getLogIterator([self::LEVEL_WARNING,self::LEVEL_ERROR,self::LEVEL_FATAL]);
+		$count = [
+			self::LEVEL_WARNING => 0,
+			self::LEVEL_ERROR => 0,
+			self::LEVEL_FATAL => 0,
+		];
+		$limit = new \DateTime('7 days ago');
+		foreach ($logIterator as $logItem) {
+			if (!isset($logItem['time'])) {
+				break;
+			}
+			$time = \DateTime::createFromFormat(\DateTime::ATOM, $logItem['time']);
+			if ($time < $limit) {
+				break;
+			}
+			$count[$logItem['level']]++;
+		}
+		if (array_sum($count) === 0) {
+			return new SetupResult(SetupResult::SUCCESS, $this->l10n->t('No errors in the logs since %s', $this->dateFormatter->formatDate($limit)));
+		} elseif ($count[self::LEVEL_ERROR] + $count[self::LEVEL_FATAL] > 0) {
+			return new SetupResult(
+				SetupResult::ERROR,
+				$this->l10n->n(
+					'%n error in the logs since %s',
+					'%n errors in the logs since %s',
+					$count[self::LEVEL_ERROR] + $count[self::LEVEL_FATAL],
+					[$this->dateFormatter->formatDate($limit)],
+				)
+			);
+		} else {
+			return new SetupResult(
+				SetupResult::WARNING,
+				$this->l10n->n(
+					'%n warning in the logs since %s',
+					'%n warnings in the logs since %s'.json_encode($count),
+					$count[self::LEVEL_WARNING],
+					[$this->dateFormatter->formatDate($limit)],
+				)
+			);
+		}
+	}
+}

--- a/tests/Unit/SetupChecks/LogErrorsTest.php
+++ b/tests/Unit/SetupChecks/LogErrorsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\LogReader\Tests\Unit\SetupChecks;
+
+use OCA\LogReader\Log\LogIteratorFactory;
+use OCA\LogReader\SetupChecks\LogErrors;
+use OCP\IConfig;
+use OCP\IDateTimeFormatter;
+use OCP\IL10N;
+use Test\TestCase;
+
+class LogErrorsTest extends TestCase {
+	private IL10N $l10n;
+	private IConfig $config;
+	private IDateTimeFormatter $dateFormatter;
+	private LogIteratorFactory $logIteratorFactory;
+	private LogErrors $logErrorsCheck;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->dateFormatter = $this->createMock(IDateTimeFormatter::class);
+		$this->logIteratorFactory = $this->createMock(LogIteratorFactory::class);
+		$this->logErrorsCheck = new LogErrors(
+			$this->l10n,
+			$this->config,
+			$this->dateFormatter,
+			$this->logIteratorFactory,
+		);
+	}
+
+	public function logProvider(): array {
+		$now = (new \DateTime())->format(\DateTime::ATOM);
+		$tooOld = (new \DateTime('1 month ago'))->format(\DateTime::ATOM);
+		return [
+			[[], 'success'],
+			[[['level' => 2, 'time' => $now]], 'warning'],
+			[[['level' => 3, 'time' => $now]], 'error'],
+			[[['level' => 2, 'time' => $now],['level' => 3, 'time' => $now]], 'error'],
+			[[['level' => 2, 'time' => $now],['level' => 3, 'time' => $tooOld]], 'warning'],
+			[[['level' => 2, 'time' => $tooOld],['level' => 3, 'time' => $tooOld]], 'success'],
+		];
+	}
+
+	/**
+	 * @dataProvider logProvider
+	 */
+	public function testSetupCheck(array $logContent, string $severity): void {
+		$logIterator = new \ArrayIterator($logContent);
+		$this->logIteratorFactory
+			->expects(self::once())
+			->method('getLogIterator')
+			->willReturn($logIterator);
+
+		$result = $this->logErrorsCheck->run();
+
+		$this->assertEquals($severity, $result->getSeverity());
+	}
+}


### PR DESCRIPTION
Requires https://github.com/nextcloud/server/pull/32550

Adds a SetupCheck for errors in the log file in the last 7 days.

- [x] Add link to logreader: not supported by server yet, postponed
- [x] Add link to documentation: supported, but do documentation would make sense here I think, postponed