### PR TITLE
Lower setup check level from error/warning to warning/info

### DIFF
--- a/lib/SetupChecks/LogErrors.php
+++ b/lib/SetupChecks/LogErrors.php
@@ -74,7 +74,7 @@ class LogErrors implements ISetupCheck {
 		if (array_sum($count) === 0) {
 			return SetupResult::success($this->l10n->t('No errors in the logs since %s', $this->dateFormatter->formatDate($limit)));
 		} elseif ($count[self::LEVEL_ERROR] + $count[self::LEVEL_FATAL] > 0) {
-			return SetupResult::error(
+			return SetupResult::warning(
 				$this->l10n->n(
 					'%n error in the logs since %s',
 					'%n errors in the logs since %s',
@@ -83,7 +83,7 @@ class LogErrors implements ISetupCheck {
 				)
 			);
 		} else {
-			return SetupResult::warning(
+			return SetupResult::info(
 				$this->l10n->n(
 					'%n warning in the logs since %s',
 					'%n warnings in the logs since %s'.json_encode($count),

--- a/tests/Unit/SetupChecks/LogErrorsTest.php
+++ b/tests/Unit/SetupChecks/LogErrorsTest.php
@@ -60,10 +60,10 @@ class LogErrorsTest extends TestCase {
 		$tooOld = (new \DateTime('1 month ago'))->format(\DateTime::ATOM);
 		return [
 			[[], 'success'],
-			[[['level' => 2, 'time' => $now]], 'warning'],
-			[[['level' => 3, 'time' => $now]], 'error'],
-			[[['level' => 2, 'time' => $now],['level' => 3, 'time' => $now]], 'error'],
-			[[['level' => 2, 'time' => $now],['level' => 3, 'time' => $tooOld]], 'warning'],
+			[[['level' => 2, 'time' => $now]], 'info'],
+			[[['level' => 3, 'time' => $now]], 'warning'],
+			[[['level' => 2, 'time' => $now],['level' => 3, 'time' => $now]], 'warning'],
+			[[['level' => 2, 'time' => $now],['level' => 3, 'time' => $tooOld]], 'info'],
 			[[['level' => 2, 'time' => $tooOld],['level' => 3, 'time' => $tooOld]], 'success'],
 		];
 	}


### PR DESCRIPTION
This check is actually almost always failing, and some errors in the logs are happenning even on normal server usage, like a DNS resolution failure for a bad link sent in Talk for instance.

So let’s make the check less frightening for the admins.