### PR TITLE
fix: Allow older app values to be set

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -49,7 +49,7 @@ class SettingsService {
 	 * Load app config if dates should be displayed as relative dates
 	 */
 	public function getRelativeDates(): bool {
-		return json_decode($this->config->getAppValue('logreader', Constants::CONFIG_KEY_RELATIVEDATES, 'false'), flags: JSON_THROW_ON_ERROR);
+		return json_decode($this->config->getAppValue('logreader', Constants::CONFIG_KEY_RELATIVEDATES, 'false') ?: 'false', flags: JSON_THROW_ON_ERROR);
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/nextcloud/logreader/issues/1073

Previously the app value `relativedates` were already used but set to an empty string in case of `false`. This needs to be handled correctly for users updating from 27 to 28.