### PR TITLE
[stable28] chore: audit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15381,9 +15381,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.0.tgz",
-			"integrity": "sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+			"integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.18.10",


### PR DESCRIPTION
Updated dependencies:
```sh
vite  4.5.0
Severity: moderate
```