### PR TITLE
[stable28] Build(deps): bump vite from 4.5.0 to 4.5.2, audit dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
 				"eslint-plugin-chai-friendly": "^0.7.2",
 				"happy-dom": "^12.10.3",
 				"typescript": "^5.2.2",
-				"vite": "^4.5.0",
+				"vite": "^4.5.2",
 				"vitest": "^0.34.6"
 			},
 			"engines": {
@@ -8538,9 +8538,9 @@
 			}
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-			"integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+			"integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -15381,9 +15381,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-			"integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+			"integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"eslint-plugin-chai-friendly": "^0.7.2",
 		"happy-dom": "^12.10.3",
 		"typescript": "^5.2.2",
-		"vite": "^4.5.0",
+		"vite": "^4.5.2",
 		"vitest": "^0.34.6"
 	},
 	"engines": {


### PR DESCRIPTION
Releases:
- https://github.com/vitejs/vite/releases/tag/v4.5.2
- https://github.com/vitejs/vite/releases/tag/v4.5.1