### PR TITLE
feat: Limit SetupCheck computing time to 5 seconds

### DIFF
--- a/lib/SetupChecks/LogErrors.php
+++ b/lib/SetupChecks/LogErrors.php
@@ -72,9 +72,6 @@ class LogErrors implements ISetupCheck {
 			}
 			$count[$logItem['level']]++;
 			if (microtime(true) > $startTime + 5) {
-				echo $logItem['time']."\n";
-				echo $this->dateFormatter->formatDate($time)."\n";
-				echo $this->dateFormatter->formatDateTime($time)."\n";
 				$limit = $time;
 				break;
 			}


### PR DESCRIPTION
See #1170 

In case of early stop, it will show in the output since when was the number of errors or warnings counted.

Also added time to the output in case the date is today.