### PR TITLE
fix(LogErrors): Handle unsupported log_type gracefully

### DIFF
--- a/lib/Exception/UnsupportedLogTypeException.php
+++ b/lib/Exception/UnsupportedLogTypeException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\LogReader\Exception;
+
+class UnsupportedLogTypeException extends \Exception {
+	public function __construct() {
+		parent::__construct('Logreader application only supports "file" log_type');
+	}
+}

--- a/lib/Log/LogIteratorFactory.php
+++ b/lib/Log/LogIteratorFactory.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\LogReader\Log;
 
+use OCA\LogReader\Exception\UnsupportedLogTypeException;
 use OCP\IConfig;
 use OCP\Log\IFileBased;
 use OCP\Log\ILogFactory;
@@ -29,7 +30,7 @@ class LogIteratorFactory {
 		$timezone = $this->config->getSystemValue('logtimezone', 'UTC');
 		$logType = $this->config->getSystemValue('log_type', 'file');
 		if ($logType !== 'file') {
-			throw new \Exception('Logreader application only supports "file" log_type');
+			throw new UnsupportedLogTypeException();
 		}
 		$log = $this->logFactory->get('file');
 		if ($log instanceof IFileBased) {

--- a/lib/SetupChecks/LogErrors.php
+++ b/lib/SetupChecks/LogErrors.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\LogReader\SetupChecks;
 
+use OCA\LogReader\Exception\UnsupportedLogTypeException;
 use OCA\LogReader\Log\LogIteratorFactory;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
@@ -40,6 +41,10 @@ class LogErrors implements ISetupCheck {
 		try {
 			$logIterator = $this->logIteratorFactory->getLogIterator([self::LEVEL_WARNING,self::LEVEL_ERROR,self::LEVEL_FATAL]);
 		} catch (\Exception $e) {
+			if ($e instanceof UnsupportedLogTypeException) {
+				return SetupResult::info($e->getMessage());
+			}
+
 			return SetupResult::error(
 				$this->l10n->t('Failed to get an iterator for log entries: %s', [$e->getMessage()])
 			);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/logreader/issues/1448

Before | After
-- | --
![image](https://github.com/user-attachments/assets/09c603b4-40d6-4cb0-bf18-5966a18885f3) | ![image](https://github.com/user-attachments/assets/a4f09d66-c0ff-4d98-8fd0-92958eb6ddc3)![image](https://github.com/user-attachments/assets/0c1c2800-556e-497c-8800-bf609c165cc1)

