### PR TITLE
fix: replace `axios` types import source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@nextcloud/router": "^3.0.0",
         "@nextcloud/typings": "^1.9.1",
         "@nextcloud/vue": "^8.23.1",
-        "axios": "^1.8.2",
         "highlight.js": "^11.11.1",
         "json-string-splitter": "^1.0.0",
         "pinia": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@nextcloud/router": "^3.0.0",
     "@nextcloud/typings": "^1.9.1",
     "@nextcloud/vue": "^8.23.1",
-    "axios": "^1.8.2",
     "highlight.js": "^11.11.1",
     "json-string-splitter": "^1.0.0",
     "pinia": "^2.3.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type { AxiosRequestConfig, AxiosResponse } from '@nextcloud/axios'
 import type { IAppSettings, INextcloud22LogEntry } from './interfaces'
-import type { AxiosRequestConfig, AxiosResponse } from 'axios'
 
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'

--- a/src/store/logging.ts
+++ b/src/store/logging.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { AxiosError } from 'axios'
+import type { AxiosError } from '@nextcloud/axios'
 import type { ILogEntry } from '../interfaces'
 
 import { defineStore } from 'pinia'


### PR DESCRIPTION
- types are re-exported by @nextcloud/axios, so no need to pin as extra dependency