### PR TITLE
fix: Do not register listener when not in console

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,7 +24,9 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
-		$context->registerEventListener(BeforeMessageLoggedEvent::class, LogListener::class);
+		if (defined('OC_CONSOLE') && \OC_CONSOLE) {
+			$context->registerEventListener(BeforeMessageLoggedEvent::class, LogListener::class);
+		}
 		$context->registerService(Formatter::class, function (ContainerInterface $c) {
 			return new Formatter(\OC::$SERVERROOT);
 		});

--- a/lib/Listener/LogListener.php
+++ b/lib/Listener/LogListener.php
@@ -23,14 +23,10 @@ class LogListener implements IEventListener {
 	private ?Console $console;
 
 	public function __construct(Formatter $formatter, SystemConfig $config) {
-		if (defined('OC_CONSOLE') && \OC_CONSOLE) {
-			$level = getenv('OCC_LOG');
-			if ($level) {
-				$terminal = new Terminal();
-				$this->console = new Console($formatter, $config, $level, $terminal->getWidth());
-			} else {
-				$this->console = null;
-			}
+		$level = getenv('OCC_LOG');
+		if ($level) {
+			$terminal = new Terminal();
+			$this->console = new Console($formatter, $config, $level, $terminal->getWidth());
 		} else {
 			$this->console = null;
 		}


### PR DESCRIPTION
Registering the listener no matter what defeats the perf optimisation done here: 
- https://github.com/nextcloud/server/pull/43529
- https://github.com/nextcloud/server/blob/cb7c82c13d5d6cf0b21b4499365460c605936c5a/lib/private/Log.php#L331-L337

Before | After
-- | --
![image](https://github.com/user-attachments/assets/ccfcea3b-6917-4cb9-90d3-4558405f39d8) | ![Screenshot From 2025-03-26 11-15-22](https://github.com/user-attachments/assets/4cd11423-a9bf-4561-834a-398b27e1aec7)