### PR TITLE
[stable30] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1692,9 +1692,9 @@
       }
     },
     "node_modules/@nextcloud/vite-config": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.5.3.tgz",
-      "integrity": "sha512-/3H5o8JnsiGCsczQUd9tUbkmAIw7/LDzB6OM2fIEH7d3h/xb8AI6X+xDeCtvQ173cMUtAxYrYozQg8BDGJJ8MQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vite-config/-/vite-config-1.5.4.tgz",
+      "integrity": "sha512-zU1O+gnmVJgSsdST7cY2D0KWBNBPnoFie8GUBXhRzVFb0P1hlcqIVxdq88h4Wc4pqDx0BHSbeSXpV77s1cZrxw==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -1703,7 +1703,7 @@
         "browserslist-to-esbuild": "^2.1.1",
         "magic-string": "^0.30.17",
         "rollup-plugin-corejs": "^1.0.1",
-        "rollup-plugin-esbuild-minify": "^1.2.0",
+        "rollup-plugin-esbuild-minify": "^1.3.0",
         "rollup-plugin-license": "^3.6.0",
         "rollup-plugin-node-externals": "^8.0.0",
         "spdx-expression-parse": "^4.0.0",
@@ -11786,9 +11786,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.18",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.18.tgz",
-      "integrity": "sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==",
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 1 of the total 16 vulnerabilities found in your project.

## Updated dependencies
* [vite](#user-content-vite)
## Fixed vulnerabilities

### `vite` <a href="#user-content-vite" id="vite">#</a>
* Vite's server.fs.deny bypassed with /. for files under project root
* Severity: **moderate**
* Reference: [https://github.com/advisories/GHSA-859w-5945-r5v3](https://github.com/advisories/GHSA-859w-5945-r5v3)
* Affected versions: 0.11.0 - 6.1.6
* Package usage:
  * `node_modules/vite`