### PR TITLE
feat: Remove unnecessary whitespaces

### DIFF
--- a/lib/Log/Formatter.php
+++ b/lib/Log/Formatter.php
@@ -51,7 +51,7 @@ class Formatter {
 
 		$argumentsString = implode(', ', $arguments);
 		$argumentWhiteSpace = str_repeat(' ', $largestIndexWidth + 2);
-		if ($argumentsString && strlen($argumentsString) < $argumentWidth) {
+		if ($argumentsString === '' || strlen($argumentsString) < $argumentWidth) {
 			return $whiteSpace . $index . '. ' . $this->getFileAndLine($trace, $argumentWidth) . "\n" .
 				$argumentWhiteSpace . $method . '(' .
 				$argumentsString . ')';


### PR DESCRIPTION
The idea is to remove unnecessary whitespace to shorten the stack traces, as follows:

- without patch :

```console
 Error     webdav              Sabre\DAV\Exception\Locked:  at 3rdparty/sabre/dav/lib/DAV/Locks/Plugin.php line 504                                                       2025-11-27T13:35:31+01:00

0. 3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
  Sabre\DAV\Locks\Plugin->validateTokens("*** sensitive parameters replaced ***")
1. 3rdparty/sabre/dav/lib/DAV/Server.php line 1448
  Sabre\DAV\Server->emit(

  )
2. 3rdparty/sabre/dav/lib/DAV/Server.php line 466
  Sabre\DAV\Server->checkPreconditions(

  )
3. apps/dav/lib/Connector/Sabre/Server.php line 211
  Sabre\DAV\Server->invokeMethod(

  )
4. apps/dav/lib/Server.php line 424
  OCA\DAV\Connector\Sabre\Server->start(

  )
5. apps/dav/appinfo/v2/remote.php line 22
  OCA\DAV\Server->exec(

  )
6. remote.php line 151
  require_once("\/var\/www\/nextcloud\/apps\/dav\/appinfo\/v2\/remote.php")
```

- with patch:

```console
 Error     webdav              Sabre\DAV\Exception\Locked:  at 3rdparty/sabre/dav/lib/DAV/Locks/Plugin.php line 504                                                       2025-11-27T13:35:31+01:00

0. 3rdparty/sabre/event/lib/WildcardEmitterTrait.php line 89
  Sabre\DAV\Locks\Plugin->validateTokens("*** sensitive parameters replaced ***")
1. 3rdparty/sabre/dav/lib/DAV/Server.php line 1448
  Sabre\DAV\Server->emit()
2. 3rdparty/sabre/dav/lib/DAV/Server.php line 466
  Sabre\DAV\Server->checkPreconditions()
3. apps/dav/lib/Connector/Sabre/Server.php line 211
  Sabre\DAV\Server->invokeMethod()
4. apps/dav/lib/Server.php line 424
  OCA\DAV\Connector\Sabre\Server->start()
5. apps/dav/appinfo/v2/remote.php line 22
  OCA\DAV\Server->exec()
6. remote.php line 151
  require_once("\/var\/www\/nextcloud\/apps\/dav\/appinfo\/v2\/remote.php")
```