### PR TITLE
fix(LogController): prevent iterator from jumping over the last item

### DIFF
--- a/lib/Controller/LogController.php
+++ b/lib/Controller/LogController.php
@@ -69,7 +69,6 @@ class LogController extends Controller {
 	 */
 	private function getLastItem() {
 		$iterator = $this->logIteratorFactory->getLogIterator($this->settingsService->getShownLevels());
-		$iterator->next();
 		return $iterator->current();
 	}
 


### PR DESCRIPTION
- Ref #1271 
  - when requesting getLastItem(), logIteratorFactory->getLogIterator() creates a new LogIterator(),
  - which in construct calls $this->rewind() -> $this->next().

So this should already return a last known line in the file, there is no need for $iterator->next() to be called again