### PR TITLE
fix(build): extract license information from .map files

### DIFF
--- a/js/index-BPdybXRh.chunk.mjs.map.license
+++ b/js/index-BPdybXRh.chunk.mjs.map.license
@@ -1,0 +1,16 @@
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Vuepic
+SPDX-FileCopyrightText: date-fns developers
+
+This file is generated from multiple sources. Included packages:
+- @nextcloud/vue
+	- version: 9.8.2
+	- license: AGPL-3.0-or-later
+- @vuepic/vue-datepicker
+	- version: 11.0.3
+	- license: MIT
+- date-fns
+	- version: 4.1.0
+	- license: MIT

--- a/js/index-Bk5K8o3u.chunk.mjs.map.license
+++ b/js/index-Bk5K8o3u.chunk.mjs.map.license
@@ -1,0 +1,21 @@
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Josh Goebel <hello@joshgoebel.com>
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+
+This file is generated from multiple sources. Included packages:
+- hast-util-to-text
+	- version: 4.0.2
+	- license: MIT
+- highlight.js
+	- version: 11.11.1
+	- license: BSD-3-Clause
+- lowlight
+	- version: 3.3.0
+	- license: MIT
+- rehype-highlight
+	- version: 7.0.2
+	- license: MIT
+- unist-util-find-after
+	- version: 5.0.0
+	- license: MIT

--- a/js/index-LLl8Rn0A.chunk.mjs.map.license
+++ b/js/index-LLl8Rn0A.chunk.mjs.map.license
@@ -1,0 +1,16 @@
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Scott Cooper <scttcper@gmail.com>
+SPDX-FileCopyrightText: chenkai
+
+This file is generated from multiple sources. Included packages:
+- @ckpack/vue-color
+	- version: 1.6.0
+	- license: MIT
+- @ctrl/tinycolor
+	- version: 3.6.1
+	- license: MIT
+- @nextcloud/vue
+	- version: 9.8.2
+	- license: AGPL-3.0-or-later

--- a/js/logreader-main.mjs.map.license
+++ b/js/logreader-main.mjs.map.license
@@ -1,0 +1,328 @@
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
+SPDX-FileCopyrightText: Andrea Giammarchi
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: David Myers <hello@davidmyers.dev>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Max <max@nextcloud.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Robin Appelman <robin@icewind.nl>
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+
+This file is generated from multiple sources. Included packages:
+- @floating-ui/core
+	- version: 1.7.5
+	- license: MIT
+- @floating-ui/dom
+	- version: 1.1.1
+	- license: MIT
+- @floating-ui/dom
+	- version: 1.7.6
+	- license: MIT
+- @floating-ui/utils
+	- version: 0.2.11
+	- license: MIT
+- @nextcloud/auth
+	- version: 2.6.0
+	- license: GPL-3.0-or-later
+- @nextcloud/axios
+	- version: 2.6.0
+	- license: GPL-3.0-or-later
+- @nextcloud/browser-storage
+	- version: 0.5.0
+	- license: GPL-3.0-or-later
+- @nextcloud/capabilities
+	- version: 1.2.1
+	- license: GPL-3.0-or-later
+- @nextcloud/dialogs
+	- version: 7.4.1
+	- license: AGPL-3.0-or-later
+- @nextcloud/event-bus
+	- version: 3.3.3
+	- license: GPL-3.0-or-later
+- @nextcloud/initial-state
+	- version: 3.0.0
+	- license: GPL-3.0-or-later
+- @nextcloud/l10n
+	- version: 3.4.1
+	- license: GPL-3.0-or-later
+- @nextcloud/logger
+	- version: 3.0.3
+	- license: GPL-3.0-or-later
+- @nextcloud/router
+	- version: 3.1.0
+	- license: GPL-3.0-or-later
+- @nextcloud/sharing
+	- version: 0.4.0
+	- license: GPL-3.0-or-later
+- @nextcloud/vue
+	- version: 9.8.2
+	- license: AGPL-3.0-or-later
+- @nextcloud/vue-select
+	- version: 4.1.0
+	- license: MIT
+- @ungap/structured-clone
+	- version: 1.2.0
+	- license: ISC
+- @vitejs/plugin-vue
+	- version: 6.0.7
+	- license: MIT
+- @vue/reactivity
+	- version: 3.5.40
+	- license: MIT
+- @vue/runtime-core
+	- version: 3.5.40
+	- license: MIT
+- @vue/runtime-dom
+	- version: 3.5.40
+	- license: MIT
+- @vue/shared
+	- version: 3.5.40
+	- license: MIT
+- @vueuse/core
+	- version: 14.3.0
+	- license: MIT
+- @vueuse/shared
+	- version: 14.3.0
+	- license: MIT
+- axios
+	- version: 1.18.1
+	- license: MIT
+- bail
+	- version: 2.0.2
+	- license: MIT
+- comma-separated-tokens
+	- version: 2.0.3
+	- license: MIT
+- debounce
+	- version: 3.0.0
+	- license: MIT
+- decode-named-character-reference
+	- version: 1.1.0
+	- license: MIT
+- devlop
+	- version: 1.1.0
+	- license: MIT
+- dompurify
+	- version: 3.4.13
+	- license: (MPL-2.0 OR Apache-2.0)
+- escape-html
+	- version: 1.0.3
+	- license: MIT
+- escape-string-regexp
+	- version: 5.0.0
+	- license: MIT
+- estree-util-is-identifier-name
+	- version: 3.0.0
+	- license: MIT
+- extend
+	- version: 3.0.2
+	- license: MIT
+- floating-vue
+	- version: 5.2.2
+	- license: MIT
+- focus-trap
+	- version: 8.2.1
+	- license: MIT
+- hast-util-is-element
+	- version: 3.0.0
+	- license: MIT
+- hast-util-to-jsx-runtime
+	- version: 2.3.6
+	- license: MIT
+- hast-util-whitespace
+	- version: 3.0.0
+	- license: MIT
+- inline-style-parser
+	- version: 0.2.7
+	- license: MIT
+- is-absolute-url
+	- version: 4.0.1
+	- license: MIT
+- is-plain-obj
+	- version: 4.1.0
+	- license: MIT
+- logreader
+	- version: 8.0.0-dev.0
+	- license: AGPL-3.0-or-later
+- mdast-squeeze-paragraphs
+	- version: 6.0.0
+	- license: MIT
+- mdast-util-find-and-replace
+	- version: 3.0.1
+	- license: MIT
+- mdast-util-from-markdown
+	- version: 2.0.2
+	- license: MIT
+- mdast-util-newline-to-break
+	- version: 2.0.0
+	- license: MIT
+- mdast-util-to-hast
+	- version: 13.2.1
+	- license: MIT
+- mdast-util-to-string
+	- version: 4.0.0
+	- license: MIT
+- micromark
+	- version: 4.0.2
+	- license: MIT
+- micromark-core-commonmark
+	- version: 2.0.3
+	- license: MIT
+- micromark-factory-destination
+	- version: 2.0.1
+	- license: MIT
+- micromark-factory-label
+	- version: 2.0.1
+	- license: MIT
+- micromark-factory-space
+	- version: 2.0.1
+	- license: MIT
+- micromark-factory-title
+	- version: 2.0.1
+	- license: MIT
+- micromark-factory-whitespace
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-character
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-chunked
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-classify-character
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-combine-extensions
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-decode-numeric-character-reference
+	- version: 2.0.2
+	- license: MIT
+- micromark-util-decode-string
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-html-tag-name
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-normalize-identifier
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-resolve-all
+	- version: 2.0.1
+	- license: MIT
+- micromark-util-sanitize-uri
+	- version: 2.0.0
+	- license: MIT
+- micromark-util-subtokenize
+	- version: 2.1.0
+	- license: MIT
+- pinia
+	- version: 4.0.2
+	- license: MIT
+- property-information
+	- version: 7.1.0
+	- license: MIT
+- rehype-external-links
+	- version: 3.0.0
+	- license: MIT
+- rehype-react
+	- version: 8.0.0
+	- license: MIT
+- remark-breaks
+	- version: 4.0.0
+	- license: MIT
+- remark-parse
+	- version: 11.0.0
+	- license: MIT
+- remark-rehype
+	- version: 11.1.2
+	- license: MIT
+- remark-unlink-protocols
+	- version: 1.0.0
+	- license: MIT
+- semver
+	- version: 7.7.3
+	- license: ISC
+- space-separated-tokens
+	- version: 2.0.2
+	- license: MIT
+- style-to-js
+	- version: 1.1.21
+	- license: MIT
+- style-to-object
+	- version: 1.0.14
+	- license: MIT
+- tabbable
+	- version: 6.4.0
+	- license: MIT
+- toastify-js
+	- version: 1.12.0
+	- license: MIT
+- trim-lines
+	- version: 3.0.1
+	- license: MIT
+- trough
+	- version: 2.1.0
+	- license: MIT
+- unified
+	- version: 11.0.5
+	- license: MIT
+- unist-builder
+	- version: 4.0.0
+	- license: MIT
+- unist-util-is
+	- version: 6.0.0
+	- license: MIT
+- unist-util-position
+	- version: 5.0.0
+	- license: MIT
+- unist-util-stringify-position
+	- version: 4.0.0
+	- license: MIT
+- unist-util-visit
+	- version: 5.1.0
+	- license: MIT
+- unist-util-visit-parents
+	- version: 6.0.2
+	- license: MIT
+- vfile
+	- version: 6.0.3
+	- license: MIT
+- vfile-message
+	- version: 4.0.3
+	- license: MIT
+- vite
+	- version: 7.3.6
+	- license: MIT
+- vite-plugin-node-polyfills
+	- version: 0.28.0
+	- license: MIT
+- vue-material-design-icons
+	- version: 5.3.1
+	- license: MIT
+- vue-router
+	- version: 5.2.0
+	- license: MIT

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,9 @@ import { createAppConfig } from '@nextcloud/vite-config'
 const config = createAppConfig({
 	main: 'src/index.ts',
 }, {
+	extractLicenseInformation: {
+		includeSourceMaps: true,
+	},
 	// Build the css/logreader-style.css instead of inlineing the styles in the js bundle
 	inlineCSS: false,
 	assetFileNames: (info) => info.name === 'index.css' ? 'css/logreader-main.css' : undefined,


### PR DESCRIPTION
- store information in .map.license files to avoid parsing compiled assets
- assets might have malformed spdx header and trigger false-positive reuse lint failures